### PR TITLE
Optimize pixel operations

### DIFF
--- a/bayer.js
+++ b/bayer.js
@@ -1,0 +1,15 @@
+function bayerDither(g){
+  g.loadPixels();
+  const M=[0,8,2,10,12,4,14,6,3,11,1,9,15,7,13,5];
+  for(let y=0;y<g.height;y++){
+    for(let x=0;x<g.width;x++){
+      const idx=4*(y*g.width+x);
+      for(let c=0;c<3;c++){
+        const old=g.pixels[idx+c];
+        const thresh=M[(y&3)*4+(x&3)]*16;
+        g.pixels[idx+c]=old<thresh?0:255;
+      }
+    }
+  }
+  g.updatePixels();
+}

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 </head>
 <body>
 <button id="save">⤓ save</button>
+<div id="fps"></div>
 
 <!-- p5.js CDN -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.3/p5.min.js"></script>
@@ -22,78 +23,93 @@ const NOISE_MAG   = 8;            // displacement strength
 const DITHER_PROB = 0.15;         // 15 % Bayer chance
 /* ------------------------------------------------------ */
 
+let gfx;
+let fpsDiv;
+let frameTimes = [];
+let bayerLoaded = false;
+
 function setup() {
   createCanvas(windowWidth, windowHeight);
-  noLoop();                       // draw() runs once
+  gfx = createGraphics(width, height);
+  colorMode(HSB, 360, 100, 100, 255);
+  gfx.colorMode(HSB, 360, 100, 100, 255);
+  fpsDiv = select('#fps');
 }
 
-function draw() {
-  background(0);
-  const cell = width / GRID_SIZE;
-  
+async function draw() {
+  const start = millis();
+  gfx.background(0);
+  const cell = gfx.width / GRID_SIZE;
+
   // 1 · draw colourful grid
   for (let y = 0; y < GRID_SIZE; y++) {
     for (let x = 0; x < GRID_SIZE; x++) {
-      fill(random(360), 80, 100);
-      rect(x*cell, y*cell, cell, cell);
+      gfx.fill(random(360), 80, 100);
+      gfx.rect(x*cell, y*cell, cell, cell);
     }
   }
   // 2 · pixel-sort some rows
-  loadPixels();
-  for (let y = 0; y < height; y++) {
+  gfx.loadPixels();
+  for (let y = 0; y < gfx.height; y++) {
     if (random() > SORT_CHANCE) continue;
     const row = [];
-    for (let x = 0; x < width; x++) {
-      const idx = 4*(y*width + x);
-      row.push( pixels.slice(idx, idx+4) );          // RGBA chunk
+    for (let x = 0; x < gfx.width; x++) {
+      const idx = 4*(y*gfx.width + x);
+      row.push( gfx.pixels.slice(idx, idx+4) );          // RGBA chunk
     }
     row.sort((a,b)=>brightness(color(...a)) - brightness(color(...b)));
-    for (let x = 0; x < width; x++) {
-      const idx = 4*(y*width + x);
-      pixels.set(row[x], idx);
+    for (let x = 0; x < gfx.width; x++) {
+      const idx = 4*(y*gfx.width + x);
+      gfx.pixels.set(row[x], idx);
     }
   }
   // 3 · noise-based displacement
-  const copy = pixels.slice();                      // snapshot before warp
-  for (let y = 0; y < height; y++) {
-    for (let x = 0; x < width; x++) {
+  const copy = gfx.pixels.slice();                      // snapshot before warp
+  for (let y = 0; y < gfx.height; y++) {
+    for (let x = 0; x < gfx.width; x++) {
       const dx = floor( noise(x*0.01, y*0.01)*NOISE_MAG );
       const dy = floor( noise(y*0.01, x*0.01)*NOISE_MAG );
-      const sx = constrain(x+dx,0,width-1);
-      const sy = constrain(y+dy,0,height-1);
-      const from = 4*(sy*width + sx);
-      const to   = 4*(y*width  + x);
-      pixels[to]=copy[from]; pixels[to+1]=copy[from+1];
-      pixels[to+2]=copy[from+2]; pixels[to+3]=255;
+      const sx = constrain(x+dx,0,gfx.width-1);
+      const sy = constrain(y+dy,0,gfx.height-1);
+      const from = 4*(sy*gfx.width + sx);
+      const to   = 4*(y*gfx.width  + x);
+      gfx.pixels[to]=copy[from]; gfx.pixels[to+1]=copy[from+1];
+      gfx.pixels[to+2]=copy[from+2]; gfx.pixels[to+3]=255;
     }
   }
-  updatePixels();
+  gfx.updatePixels();
 
-  // 4 · optional Bayer dithering
-  if (random() < DITHER_PROB) bayerDither();
+  // 4 · optional Bayer dithering loaded on demand
+  if (random() < DITHER_PROB) {
+    await loadBayer();
+    bayerDither(gfx);
+  }
+
+  background(0);
+  image(gfx, 0, 0, width, height);
+
+  frameTimes.push(millis() - start);
+  if (frameTimes.length > 60) frameTimes.shift();
+  fpsDiv.html(nf(frameRate(), 2, 2) + ' fps');
 }
 
-/* --- tiny 4x4 Bayer matrix --- */
-function bayerDither(){
-  loadPixels();
-  const M=[0,8,2,10,12,4,14,6,3,11,1,9,15,7,13,5];
-  for (let y=0;y<height;y++){
-    for (let x=0;x<width;x++){
-      const idx=4*(y*width+x);
-      for (let c=0;c<3;c++){
-        const old=pixels[idx+c];
-        const thresh = M[ (y&3)*4 + (x&3) ]*16;
-        pixels[idx+c]= old<thresh?0:255;
-      }
-    }
-  }
-  updatePixels();
+function loadBayer(){
+  return new Promise((resolve)=>{
+    if(bayerLoaded){ resolve(); return; }
+    const s=document.createElement('script');
+    s.src='bayer.js';
+    s.onload=()=>{bayerLoaded=true; resolve();};
+    document.body.appendChild(s);
+  });
 }
 
 /* --- save PNG --- */
 document.getElementById('save').onclick=()=>saveCanvas('grid','png');
 
-function windowResized(){resizeCanvas(windowWidth,windowHeight); redraw();}
+function windowResized(){
+  resizeCanvas(windowWidth,windowHeight);
+  gfx = createGraphics(width, height);
+}
 </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "cdxgent",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node test/fps.js"
+  },
+  "devDependencies": {
+    "puppeteer": "^22.7.1"
+  }
+}

--- a/test/fps.js
+++ b/test/fps.js
@@ -1,0 +1,18 @@
+const puppeteer = require('puppeteer');
+const path = require('path');
+
+(async () => {
+  const browser = await puppeteer.launch({args: ['--no-sandbox'], headless: true});
+  const page = await browser.newPage();
+  await page.setViewport({width:1280, height:720});
+  await page.goto('file://' + path.resolve(__dirname, '../index.html'));
+  await page.waitForFunction('window.frameTimes && window.frameTimes.length >= 60', {timeout: 10000});
+  const avg = await page.evaluate('window.frameTimes.reduce((a,b)=>a+b)/window.frameTimes.length');
+  console.log('Average frame time:', avg);
+  await browser.close();
+  if (avg >= 30) {
+    console.error('Average frame time too high:', avg);
+    process.exit(1);
+  }
+  console.log('Performance OK');
+})();


### PR DESCRIPTION
## Summary
- move pixel manipulation to p5.Graphics buffer
- lazily load Bayer dithering script
- display live FPS counter
- add test script to measure average frame time

## Testing
- `npm install` *(fails: EHOSTUNREACH)*
- `npm test` *(fails: Cannot find module 'puppeteer')*